### PR TITLE
Fix identation breaking the for loop - Closes #1

### DIFF
--- a/statuscake.py
+++ b/statuscake.py
@@ -32,7 +32,7 @@ def get_tests():
             metrics['up'].labels(test['WebsiteName'], test['TestID']).set(0)
 
         metrics['uptime'].labels(test['WebsiteName'], test['TestID']).set(test['Uptime'])
-        return [{'id': test['TestID'], 'name': test['WebsiteName']} for test in tests]
+    return [{'id': test['TestID'], 'name': test['WebsiteName']} for test in tests]
 
 
 def get_checks(test):


### PR DESCRIPTION
Fix an identation problem with the get_tests function since return statement breaks the for loop and just return the first metric in the up and uptime metrics